### PR TITLE
Added support for https, and jQuery.noConflict use

### DIFF
--- a/jquery.geolocation.edit.js
+++ b/jquery.geolocation.edit.js
@@ -221,7 +221,7 @@
 
 			script = document.createElement("script");
 			script.type = "text/javascript";
-			script.src = "http://maps.googleapis.com/maps/api/js?sensor=false&callback=$.fn.geolocateGMapsLoaded";
+			script.src = ( window.location.protocol == 'https:' ? 'https' : 'http' ) + '://maps.googleapis.com/maps/api/js?sensor=false&callback=jQuery.fn.geolocateGMapsLoaded';
 			document.body.appendChild(script);
 		};
 	})();

--- a/jquery.geolocation.edit.js
+++ b/jquery.geolocation.edit.js
@@ -45,6 +45,7 @@
 		var opts = $.extend(true, {
 			address: [],
 			changeOnEdit: false,
+			readOnlyMap: false, // don't allow pin movement on click
 			mapOptions: {
 				zoom: 14,
 				mapTypeId: google.maps.MapTypeId.ROADMAP,
@@ -119,10 +120,12 @@
 		});
 
 		// Move the marker to the location user clicks
-		gmaps.event.addListener(map, 'click', function (event) {
-			marker.setPosition(event.latLng);
-			$(self).geolocate({}, 'getMarkerLocation');
-		});
+		if (!opts.readOnlyMap) {
+			gmaps.event.addListener(map, 'click', function (event) {
+				marker.setPosition(event.latLng);
+				$(self).geolocate({}, 'getMarkerLocation');
+			});
+		}
 	};
 
 


### PR DESCRIPTION
As per issue #3.

A couple of small fixes to make the code a bit more robust:

  * Currently doesn't support using the script on a https:// encoded page. Throws a security error for trying to load a (hardcoded) insecure script
  * Doesn't support jQuery.noConflict() being used (callback code assumes $ will be bound to jQuery)

Have implemented & tested the following fix to line 225 of ``jquery.geolocation.edit.js``:

```javascript
script.src = ( window.location.protocol == 'https:' ? 'https' : 'http' ) + '://maps.googleapis.com/maps/api/js?sensor=false&callback=jQuery.fn.geolocateGMapsLoaded';
```

Fix is to detect https, and also to use ``jQuery`` for the callback instead of ``$``